### PR TITLE
added auto focus (JS) to the password space

### DIFF
--- a/phpminiadmin.php
+++ b/phpminiadmin.php
@@ -387,7 +387,7 @@ function sht(f){
 </script>
 
 </head>
-<body onload="after_load()">
+<body onload="after_load();document.DF.pwd.focus();">
 <form method="post" name="DF" action="<?php echo $self?>" enctype="multipart/form-data">
 <input type="hidden" name="XSS" value="<?php echo $_SESSION['XSS']?>">
 <input type="hidden" name="refresh" value="">


### PR DESCRIPTION
To allow auto focusing on the text box for password (landing page) for quick entry of password. 
Code: document.DF.pwd.focus(); on line 390
