### PR TITLE
Issue With session_destroy() And A Few Other Suggestions

### DIFF
--- a/samples/phpminiconfig.php
+++ b/samples/phpminiconfig.php
@@ -1,5 +1,10 @@
 <?php
- $ACCESS_PWD=''; #!!!IMPORTANT!!! this is script access password, SET IT if you want to protect you DB from public access
+$ACCESS_PWD=''; #!!!IMPORTANT!!! this is script access password, SET IT if you want to protect you DB from public access
+
+$authPage = ""; // Include your own Authenticator File if exist.
+
+// date_default_timezone_set("Asia/Bangkok");
+// ini_set('display_errors',1);
 
  #DEFAULT db connection settings
  # --- WARNING! --- if you set defaults - it's recommended to set $ACCESS_PWD to protect your db!
@@ -16,4 +21,4 @@
  'ssl_cert'=>NULL,
  'ssl_ca'=>"",#minimum this is required for ssl connections, if set - ssl connection will try to be established. Example: /path/to/cacert.pem
  );
-
+?>


### PR DESCRIPTION
**Problem I :** 
Logout function run session_destroy(). Destroying all active session of the website.
**Solution :**
Change all phpMiniAdmin session variables into $_SESSION['pmAdmin'], so we can just use unset($_SESSION['pmAdmin']) instead of session_destroy(). So it doesn't destroy the whole website active session

**Suggestion I :**
Move phpminiconfig.php include line (from line 32 to line 53), so the config can override all previous variables above it
Adding few line in the config file for example ($authPage, default timezone, display_errors) if **Suggestion I** is accepted

**Suggestion II :**
Adding your own user privilege authenticator $authPage (if any). Instead of using $ACCESS_PWD as an authenticator, your ability to open phpMiniAdmin would be dictated by whether you're already login from the main website / main auth function or not.
**Example :**
$authPage = "session.php"; //Will include session.php if file exist
